### PR TITLE
Build shell script cleanup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ set -e
 }
 
 # get config
-if [ -n "$1" ]; then
+if [[ -n "$1" ]]; then
   CONFIG_FILE="$1"
 else
   CONFIG_FILE="etc/terraform.conf"

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 # check for root permissions
 (( EUID )) && {
 
-    echo "E: Requires root permissions" > /dev/stderr
+    echo "E: Requires root permissions" >&2
 
     exit 1
 }

--- a/build.sh
+++ b/build.sh
@@ -13,10 +13,14 @@ set -e
 # get config
 if [[ -n "$1" ]]; then
   CONFIG_FILE="$1"
+
 else
   CONFIG_FILE="etc/terraform.conf"
+
 fi
+
 BASE_DIR="${PWD}"
+
 source "${BASE_DIR}"/"${CONFIG_FILE}"
 
 echo -e "
@@ -26,18 +30,23 @@ echo -e "
 "
 
 apt-get update
+
 apt-get install -y patch gnupg2 binutils zstd ubuntu-keyring apt-utils
+
 ln -sfn /usr/share/debootstrap/scripts/gutsy /usr/share/debootstrap/scripts/devel
 
 build () {
+
   BUILD_ARCH="$1"
 
   mkdir -p "${BASE_DIR}/tmp/${BUILD_ARCH}"
+
   cd "${BASE_DIR}/tmp/${BUILD_ARCH}" || exit
 
   # remove old configs and copy over new
   rm -rf config auto
   cp -r "${BASE_DIR}"/etc/* .
+
   # Make sure conffile specified as arg has correct name
   cp -f "${BASE_DIR}"/"${CONFIG_FILE}" terraform.conf
 
@@ -72,21 +81,29 @@ build () {
 "
 
   OUTPUT_DIR="${BASE_DIR}/builds/${BUILD_ARCH}"
+
   mkdir -p "${OUTPUT_DIR}"
+
   FNAME="Rolling-Linux-OS-${VERSION}${OUTPUT_SUFFIX}"
+
   mv "${BASE_DIR}/tmp/${BUILD_ARCH}/live-image-${BUILD_ARCH}.hybrid.iso" "${OUTPUT_DIR}/${FNAME}.iso"
 
   # cd into output to so {FNAME}.sha256.txt only
   # includes the filename and not the path to
   # our file.
   cd "${OUTPUT_DIR}"
+
   sha512sum "${FNAME}.iso" > "${FNAME}.sha512"
+
   sha256sum "${FNAME}.iso" > "${FNAME}.sha256"
+
   cd "${BASE_DIR}"
 }
 
 if [[ "${ARCH}" == "all" ]]; then
     build amd64
+
 else
     build "${ARCH}"
+
 fi

--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,8 @@ if [[ -n "$1" ]]; then
 else
   CONFIG_FILE="etc/terraform.conf"
 fi
-BASE_DIR="$PWD"
-source "$BASE_DIR"/"$CONFIG_FILE"
+BASE_DIR="${PWD}"
+source "${BASE_DIR}"/"${CONFIG_FILE}"
 
 echo -e "
 #----------------------#
@@ -32,17 +32,17 @@ ln -sfn /usr/share/debootstrap/scripts/gutsy /usr/share/debootstrap/scripts/deve
 build () {
   BUILD_ARCH="$1"
 
-  mkdir -p "$BASE_DIR/tmp/$BUILD_ARCH"
-  cd "$BASE_DIR/tmp/$BUILD_ARCH" || exit
+  mkdir -p "${BASE_DIR}/tmp/${BUILD_ARCH}"
+  cd "${BASE_DIR}/tmp/${BUILD_ARCH}" || exit
 
   # remove old configs and copy over new
   rm -rf config auto
-  cp -r "$BASE_DIR"/etc/* .
+  cp -r "${BASE_DIR}"/etc/* .
   # Make sure conffile specified as arg has correct name
-  cp -f "$BASE_DIR"/"$CONFIG_FILE" terraform.conf
+  cp -f "${BASE_DIR}"/"${CONFIG_FILE}" terraform.conf
 
   # Symlink chosen package lists to where live-build will find them
-  ln -s "package-lists.$PACKAGE_LISTS_SUFFIX" "config/package-lists"
+  ln -s "package-lists.${PACKAGE_LISTS_SUFFIX}" "config/package-lists"
 
   echo -e "
 #------------------#
@@ -71,22 +71,22 @@ build () {
 #---------------------------#
 "
 
-  OUTPUT_DIR="$BASE_DIR/builds/$BUILD_ARCH"
-  mkdir -p "$OUTPUT_DIR"
-  FNAME="Rolling-Linux-OS-$VERSION$OUTPUT_SUFFIX"
-  mv "$BASE_DIR/tmp/$BUILD_ARCH/live-image-$BUILD_ARCH.hybrid.iso" "$OUTPUT_DIR/${FNAME}.iso"
+  OUTPUT_DIR="${BASE_DIR}/builds/${BUILD_ARCH}"
+  mkdir -p "${OUTPUT_DIR}"
+  FNAME="Rolling-Linux-OS-${VERSION}${OUTPUT_SUFFIX}"
+  mv "${BASE_DIR}/tmp/${BUILD_ARCH}/live-image-${BUILD_ARCH}.hybrid.iso" "${OUTPUT_DIR}/${FNAME}.iso"
 
   # cd into output to so {FNAME}.sha256.txt only
   # includes the filename and not the path to
   # our file.
-  cd $OUTPUT_DIR
+  cd ${OUTPUT_DIR}
   sha512sum "${FNAME}.iso" > "${FNAME}.sha512"
   sha256sum "${FNAME}.iso" > "${FNAME}.sha256"
-  cd $BASE_DIR
+  cd ${BASE_DIR}
 }
 
-if [[ "$ARCH" == "all" ]]; then
+if [[ "${ARCH}" == "all" ]]; then
     build amd64
 else
-    build "$ARCH"
+    build "${ARCH}"
 fi

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,12 @@
 set -e
 
 # check for root permissions
-if [[ "$(id -u)" != 0 ]]; then
-  echo "E: Requires root permissions" > /dev/stderr
-  exit 1
-fi
+(( EUID )) && {
+
+    echo "E: Requires root permissions" > /dev/stderr
+
+    exit 1
+}
 
 # get config
 if [ -n "$1" ]; then

--- a/build.sh
+++ b/build.sh
@@ -79,10 +79,10 @@ build () {
   # cd into output to so {FNAME}.sha256.txt only
   # includes the filename and not the path to
   # our file.
-  cd ${OUTPUT_DIR}
+  cd "${OUTPUT_DIR}"
   sha512sum "${FNAME}.iso" > "${FNAME}.sha512"
   sha256sum "${FNAME}.iso" > "${FNAME}.sha256"
-  cd ${BASE_DIR}
+  cd "${BASE_DIR}"
 }
 
 if [[ "${ARCH}" == "all" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -91,13 +91,13 @@ build () {
   # cd into output to so {FNAME}.sha256.txt only
   # includes the filename and not the path to
   # our file.
-  cd "${OUTPUT_DIR}"
+  cd "${OUTPUT_DIR}" || exit
 
   sha512sum "${FNAME}.iso" > "${FNAME}.sha512"
 
   sha256sum "${FNAME}.iso" > "${FNAME}.sha256"
 
-  cd "${BASE_DIR}"
+  cd "${BASE_DIR}" || exit
 }
 
 if [[ "${ARCH}" == "all" ]]; then


### PR DESCRIPTION
I made some changes to make `build.sh` more readable, robust and performant.

#### Changes:

* Quoted parameter expansions in `cd` commands
* Replaced *classic* test command for Bash's version (*i.e* `[[`)
* Replaced command substitution to get current effective user-id
* Added `exit` commands to handle failure when changing directories

Thanks for reading!