### PR TITLE
Add Korean Language Pack

### DIFF
--- a/etc/config/package-lists.calamares/desktop.list.chroot_install
+++ b/etc/config/package-lists.calamares/desktop.list.chroot_install
@@ -50,3 +50,4 @@ qt5-style-kvantum-themes
 mugshot
 fonts-firacode
 mpv
+language-pack-ko

--- a/etc/config/package-lists.calamares/desktop.list.chroot_live
+++ b/etc/config/package-lists.calamares/desktop.list.chroot_live
@@ -3,6 +3,7 @@ expect
 gparted
 cifs-utils
 language-pack-en
+language-pack-ko
 xfsprogs
 jfsutils
 reiserfsprogs


### PR DESCRIPTION
This PR fixes an issue where Korean characters are not visible in the Rhino Linux environment.