### PR TITLE
fix: always umount module

### DIFF
--- a/etc/config/hooks/live/002-install-pacstall.chroot
+++ b/etc/config/hooks/live/002-install-pacstall.chroot
@@ -18,6 +18,7 @@ export GITHUB_ACTIONS=true
 
 # Install pacstall
 sudo bash -c "$(curl -fsSL https://pacstall.dev/q/install\?dnt || wget -q https://pacstall.dev/q/install\?dnt -O -)"
+
 # WORKAROUND to trust CD Add
 sudo rm /etc/calamares/modules/before_bootloader_context.conf
 sudo touch /etc/calamares/modules/before_bootloader_context.conf
@@ -50,4 +51,20 @@ firmwareType:
              timeout: 300
         -    command: apt install -y --no-upgrade -o Acquire::gpgv::Options::=--ignore-time-conflict shim-signed
              timeout: 300
+__EOF__
+
+# Unmount partition of even if installation fails
+sudo cat > /etc/calamares/modules/umount.conf << __EOF__
+  GNU nano 7.2                       umount.conf                                
+### Umount Module
+#
+# This module represents the last part of the installation, the unmounting
+# of partitions used for the install.  After this, there is no regular way
+# to modify the target system anymore.
+#
+
+---
+# Setting emergency to true will make it so this module is still run
+# when a prior module fails
+emergency: true
 __EOF__

--- a/etc/config/hooks/live/002-install-pacstall.chroot
+++ b/etc/config/hooks/live/002-install-pacstall.chroot
@@ -55,16 +55,12 @@ __EOF__
 
 # Unmount partition of even if installation fails
 sudo cat > /etc/calamares/modules/umount.conf << __EOF__
-  GNU nano 7.2                       umount.conf                                
-### Umount Module
-#
 # This module represents the last part of the installation, the unmounting
 # of partitions used for the install.  After this, there is no regular way
 # to modify the target system anymore.
 #
 
 ---
-# Setting emergency to true will make it so this module is still run
-# when a prior module fails
+# when a prior module fails this will still run anyway
 emergency: true
 __EOF__


### PR DESCRIPTION
If a installation failed, the partition would still be mounted and could not be unmounted. This fixes that issue.