### PR TITLE
Fix unbootable systems with LUKS

### DIFF
--- a/etc/config/package-lists.calamares/desktop.list.chroot_install
+++ b/etc/config/package-lists.calamares/desktop.list.chroot_install
@@ -71,3 +71,4 @@ wireplumber
 pipewire
 pipewire-pulse
 firmware-sof-signed
+cryptsetup-initramfs


### PR DESCRIPTION
Fixes disk decryption for people who installed RL with LUKS encryption. Before the initrfs would have issues:
![Screenshot from 2023-08-20 13-49-35](https://github.com/rhino-linux/os/assets/96554164/7c355ad4-1721-4c36-88d5-87a67e54d586)