### PR TITLE
rm: `celeste-bin`

### DIFF
--- a/etc/config/hooks/live/099-install-custom-apps.chroot
+++ b/etc/config/hooks/live/099-install-custom-apps.chroot
@@ -24,7 +24,7 @@ if [[ $(dpkg --print-architecture) = arm64 ]]; then
 else
     FIREFOX="firefox-bin"
 fi
-SUDO_USER=rhino-live pacstall -QPINs nala-deb ${FIREFOX} vscodium-deb celeste-bin linux-kernel-stable rhino-core quintom-cursor-theme-git timeshift fake-ubuntu-advantage-tools-deb
+SUDO_USER=rhino-live pacstall -QPINs nala-deb ${FIREFOX} vscodium-deb linux-kernel-stable rhino-core quintom-cursor-theme-git timeshift fake-ubuntu-advantage-tools-deb
 SUDO_USER=rhino-live pacstall -QPINs rhino-setup-bin
 
 #Hack: arm64 firefox no snap

--- a/ub2r.sh
+++ b/ub2r.sh
@@ -314,12 +314,12 @@ function select_core() {
         ;;
       2)
         core_package="rhino-ubxi-core"
-        packages+=("celeste-bin" "timeshift" "${core_package}")
+        packages+=("timeshift" "${core_package}")
         break
         ;;
       3)
         core_package="rhino-core"
-        packages+=("celeste-bin" "timeshift" "quintom-cursor-theme-git" "${core_package}" "rhino-setup-bin")
+        packages+=("timeshift" "quintom-cursor-theme-git" "${core_package}" "rhino-setup-bin")
         break
         ;;
       *) ;;


### PR DESCRIPTION
AJ also thinks it's useless at this point.

Also this helps our "lightweight" look, as many people have rightly pointed out that it looks weird to have a desktop syncing app on a base install of a distro.